### PR TITLE
SD-Card writing fix and format debug messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ void setup()
     lightLed();
   }
 
-  File logfile = SD.open(filename, FILE_WRITE);
+  logfile = SD.open(filename, FILE_WRITE);
   if (logfile)
   {
     logfile.println("> LOG BOOTED");
@@ -61,11 +61,13 @@ void loop()
   if (Serial1.available())
   {
     Serial1.readBytesUntil('\n', buffer, sizeof(buffer) - 1);
+    Serial.printf(PSTR("received: %s\n"), buffer);
+
     if (!logfile.print(buffer))
     {
-      Serial.printf(PSTR("Failed to write: ")); // for debugging
+      Serial.printf(PSTR("Failed to print!\n")); // for debugging
     }
-    Serial.print(buffer);
+    logfile.flush();
     lightLed();
     memset(buffer, 0, sizeof(buffer));
   }


### PR DESCRIPTION
We were encountering two main bugs:
1. The Adalogger was receiving serial messages and not writing to the SD card
2. Writing was failing in the first 10 minutes and not after

To solve this we did:
1. Added a flush() after recieving the buffer to write to the SD card
2. Changed the logfile variable in setup() to change the global logfile and not a local one

We additionally added a 'recieved: ' debug 
message for clearer debugging